### PR TITLE
Minor workflow fixes

### DIFF
--- a/.github/workflows/automated_tests.yaml
+++ b/.github/workflows/automated_tests.yaml
@@ -4,6 +4,9 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Tests:
+    concurrency:
+      group: ${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +24,16 @@ jobs:
       - name: Run tests
         run: sudo python "$GITHUB_WORKSPACE/scripts/tests/runner.py"
 
+      - name: Print build log on failure
+        if: failure()
+        run: cat /tmp/alkOS_build.log
+
+      - name: Print test logs on failure
+        if: failure()
+        run: cat scripts/tests/test_framework_logs/*
+
       - name: Upload build artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: alkos_build
@@ -31,6 +43,7 @@ jobs:
           compression-level: 9
 
       - name: Upload tests artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: tests_logs

--- a/.github/workflows/automated_tests.yaml
+++ b/.github/workflows/automated_tests.yaml
@@ -1,12 +1,9 @@
 name: Automated Tests
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   Tests:
-    concurrency:
-      group: ${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cxx_linter.yaml
+++ b/.github/workflows/cxx_linter.yaml
@@ -1,6 +1,6 @@
 name: C++ linting
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   Lint:

--- a/.github/workflows/python_linter.yaml
+++ b/.github/workflows/python_linter.yaml
@@ -1,6 +1,6 @@
 name: Python linting
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   Lint:


### PR DESCRIPTION
* Made all workflows only trigger on a push. There is no need to run them on pull request if they happen on push anyway, this avoids duplicate jobs.
* Added steps to print the build log and test logs if any failures occur during the workflow execution. (`.github/workflows/automated_tests.yaml`)
* Updated the artifact upload steps to always run, ensuring that build and test logs are uploaded regardless of the workflow outcome. (`.github/workflows/automated_tests.yaml`)