### PR TITLE
Jlisowskyy/traces libc

### DIFF
--- a/alkos/CMakeLists.txt
+++ b/alkos/CMakeLists.txt
@@ -75,18 +75,8 @@ set(SYSTEM_LIB_TYPE k)
 
 # Add the subdirectories
 add_subdirectory(libc)
-
-target_include_directories(libk PRIVATE
-        kernel/include
-        kernel/abi
-)
-
-target_include_directories(libk.32 PRIVATE
-        kernel/include
-        kernel/abi
-)
-
 add_subdirectory(kernel)
+
 if (NOT DEFINED BOOTABLE_KERNEL_EXECUTABLE)
     message(FATAL_ERROR "No primary kernel executable defined")
 endif()

--- a/alkos/kernel/CMakeLists.txt
+++ b/alkos/kernel/CMakeLists.txt
@@ -81,9 +81,16 @@ add_executable(alkos.kernel
 
 ############################### Adding Headers ###############################
 
-include_directories(include)
-include_directories(test)
-include_directories(abi)
+add_library(alkos.kernel.headers INTERFACE)
+target_include_directories(alkos.kernel.headers INTERFACE
+    include
+    test
+    abi
+)
+
+target_link_libraries(alkos.kernel PRIVATE
+    alkos.kernel.headers
+)
 
 ########################## Configure for given Arch ##########################
 

--- a/alkos/kernel/arch/x86_64/common-loader-64-kernel/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-64-kernel/CMakeLists.txt
@@ -44,6 +44,10 @@ set_source_files_properties(${COMMON_ASM} PROPERTIES COMPILE_FLAGS "-f elf64")
 
 ############################### Adding Headers ###############################
 
-target_include_directories(arch.common.kernel-loader.64 PUBLIC
+target_include_directories(alkos.kernel.headers INTERFACE
     .
+)
+
+target_link_libraries(arch.common.kernel-loader.64 PRIVATE
+        alkos.kernel.headers
 )

--- a/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
@@ -76,10 +76,6 @@ target_link_libraries(arch.common.all.64 PRIVATE
         alkos.kernel.headers
 )
 
-target_include_directories(arch.common.all.32 PUBLIC
-    .
-)
-
 target_link_libraries(arch.common.all.32 PRIVATE
         alkos.kernel.headers
 )

--- a/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
@@ -68,10 +68,18 @@ set_source_files_properties(${COMMON_ASM} PROPERTIES COMPILE_FLAGS "-f elf64")
 
 ############################### Adding Headers ###############################
 
-target_include_directories(arch.common.all.64 PUBLIC
+target_include_directories(alkos.kernel.headers INTERFACE
     .
+)
+
+target_link_libraries(arch.common.all.64 PRIVATE
+        alkos.kernel.headers
 )
 
 target_include_directories(arch.common.all.32 PUBLIC
     .
+)
+
+target_link_libraries(arch.common.all.32 PRIVATE
+        alkos.kernel.headers
 )

--- a/alkos/kernel/arch/x86_64/kernel/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/kernel/CMakeLists.txt
@@ -25,7 +25,7 @@ target_sources(alkos.kernel PRIVATE ${ARCH_SOURCES})
 
 ############################### Adding Headers ###############################
 
-target_include_directories(alkos.kernel PRIVATE
+target_include_directories(alkos.kernel.headers INTERFACE
         .
 )
 

--- a/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
@@ -61,4 +61,5 @@ target_link_libraries(alkos.loader32 PRIVATE
         gcc
         arch.common.all.32
         libk.32
+        alkos.kernel.headers
 )

--- a/alkos/kernel/arch/x86_64/loader64/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/loader64/CMakeLists.txt
@@ -45,4 +45,5 @@ target_link_libraries(alkos.loader64 PRIVATE
         libk
         arch.common.all.64
         arch.common.kernel-loader.64
+        alkos.kernel.headers
 )

--- a/alkos/libc/CMakeLists.txt
+++ b/alkos/libc/CMakeLists.txt
@@ -76,6 +76,10 @@ target_include_directories(lib${LIB_NAME} PRIVATE
 
 target_link_libraries(lib${LIB_NAME} PRIVATE gcc)
 
+if (SYSTEM_LIB_TYPE STREQUAL "k" OR SYSTEM_LIB_TYPE STREQUAL "K")
+    target_link_libraries(lib${LIB_NAME} PRIVATE alkos.kernel.headers)
+endif ()
+
 ############################### Processing output ###############################
 
 file(MAKE_DIRECTORY ${SYSROOT}/usr/include)

--- a/alkos/libc/arch/x86_64/CMakeLists.txt
+++ b/alkos/libc/arch/x86_64/CMakeLists.txt
@@ -19,6 +19,10 @@ target_include_directories(lib${LIB_NAME}.32 PRIVATE
 
 add_dependencies(lib${LIB_NAME}.32 lib${LIB_NAME})
 
+if (SYSTEM_LIB_TYPE STREQUAL "k" OR SYSTEM_LIB_TYPE STREQUAL "K")
+    target_link_libraries(lib${LIB_NAME}.32 PRIVATE alkos.kernel.headers)
+endif ()
+
 ############################### Processing output ###############################
 
 set_target_properties(lib${LIB_NAME}.32 PROPERTIES

--- a/alkos/libc/include/extensions/debug.hpp
+++ b/alkos/libc/include/extensions/debug.hpp
@@ -3,9 +3,7 @@
 
 #include <todo.h>
 
-TODO_STREAMS
-/* Note: Currently works only in kernel code due to lack of libc terminal abstractions */
-#if defined(__USE_DEBUG_TRACES__) && defined(__ALKOS_KERNEL__)
+#if defined(__USE_DEBUG_TRACES__)
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
Things done in this PR:
- added new interface target alkos.kernel.headers to store all crucial kernel headers
- linked libk with alkos.kernel.headers
- allowed traces to be used in libk

Example:
![image](https://github.com/user-attachments/assets/6ad25044-13f4-41cf-bcfa-d9bd4eb16813)
![image](https://github.com/user-attachments/assets/fd9eeae1-8c52-44d0-9d01-5d90b97e53f4)
