### PR TITLE
Kryczkal/cmake modularization 02

### DIFF
--- a/alkos/CMakeLists.txt
+++ b/alkos/CMakeLists.txt
@@ -20,6 +20,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(ValidationHelpers)
 include(SourceHelpers)
 
+add_library(target.properties INTERFACE) # Populated by the toolchain file
+
 ################################################################################
 #                                  Conf file                                   #
 ################################################################################

--- a/alkos/kernel/CMakeLists.txt
+++ b/alkos/kernel/CMakeLists.txt
@@ -107,19 +107,6 @@ add_subdirectory(thirdparty)
 
 target_link_libraries(alkos.kernel PRIVATE libk gcc ${THIRD_PARTY_LIBRARIES} AutoGenLib)
 
-############################## Post Arch Action ##############################
-
-# Note: architecture file has a possibility to define custom command to run
-# before linking
-if (DEFINED POST_ARCH_ACTION)
-    message(STATUS "POST ACTION: ${POST_ARCH_ACTION}")
-
-    add_custom_command(TARGET alkos.kernel PRE_LINK
-            COMMAND ${POST_ARCH_ACTION}
-            COMMENT "Running post build arch action"
-    )
-endif ()
-
 ############## Linker Configuration for CXX Global Constructors ##############
 # Set the linker to link objects in the correct order
 # NOTE: ARCH cmake is expected to provide variables for global constructors

--- a/alkos/kernel/arch/x86_64/common-loader-64-kernel/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-64-kernel/CMakeLists.txt
@@ -1,35 +1,18 @@
 message(STATUS "Configuring common-loader-64-kernel")
 
-############################## Finding Sources ###############################
-
-file(GLOB_RECURSE COMMON_SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
-)
-
-file(GLOB_RECURSE COMMON_ASM
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.s"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.S"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.asm"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.nasm"
-)
-
 ############################## Preparing targets ###############################
 
 add_library(arch.common.kernel-loader.64 OBJECT
-        ${COMMON_SOURCES}
-        ${COMMON_ASM}
 )
+############################## Finding Sources ###############################
+
+alkos_target_sources(arch.common.kernel-loader.64)
 
 ######################### Setting Custom Properties ##########################
 
-target_compile_options(arch.common.kernel-loader.64 PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
+target_link_libraries(arch.common.kernel-loader.64 PRIVATE
+        target.properties
 )
-
 
 ############################# Linking libraries ##############################
 
@@ -37,10 +20,6 @@ target_link_libraries(arch.common.kernel-loader.64 PRIVATE
         libk
         arch.common.all.64
 )
-
-############################### Applying Flags ###############################
-
-set_source_files_properties(${COMMON_ASM} PROPERTIES COMPILE_FLAGS "-f elf64")
 
 ############################### Adding Headers ###############################
 

--- a/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
@@ -24,12 +24,7 @@ target_link_libraries(arch.common.all.32 PRIVATE
 
 ############################### Applying Flags ###############################
 
-target_compile_options(arch.common.all.32 PRIVATE "-m32")
-
 set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> <INCLUDES> <FLAGS> -o <OBJECT> <SOURCE>")
-
-set_source_files_properties(${COMMON_ASM_32} PROPERTIES COMPILE_FLAGS "-f elf32")
-set_source_files_properties(${COMMON_ASM} PROPERTIES COMPILE_FLAGS "-f elf64")
 
 ############################### Adding Headers ###############################
 

--- a/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/common-loader-all/CMakeLists.txt
@@ -1,64 +1,26 @@
 message(STATUS "Configuring x86_64 common-loader-all")
 
-############################## Finding Sources ###############################
-
-# TODO: Update this when there is a separate solution to applying custom properties based on file extensions
-# for .c, .cpp and .asm files, prefferably from an arch defined preset
-
-file(GLOB_RECURSE COMMON_SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
-)
-
-file(GLOB_RECURSE COMMON_ASM
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.s"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.S"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.asm"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.nasm"
-)
-
-file(GLOB_RECURSE COMMON_ASM_32
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.s"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.S"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.asm"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.nasm"
-)
-
 ############################## Preparing targets ###############################
 
-add_library(arch.common.all.64 OBJECT
-        ${COMMON_SOURCES}
-        ${COMMON_ASM}
-)
+add_library(arch.common.all.64 OBJECT)
+add_library(arch.common.all.32 OBJECT)
 
-add_library(arch.common.all.32 OBJECT
-        ${COMMON_SOURCES}
-        ${COMMON_ASM_32}
-)
+############################## Finding Sources ###############################
+
+alkos_target_sources(arch.common.all.64)
+alkos_target_sources(arch.common.all.32)
 
 ############################# Linking libraries ##############################
 
 target_link_libraries(arch.common.all.64 PRIVATE
         libk
+        target.properties
 )
 
 target_link_libraries(arch.common.all.32 PRIVATE
         libk.32
+        target.properties.32
 )
-
-######################### Setting Custom Properties ##########################
-
-target_compile_options(arch.common.all.64 PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
-)
-target_compile_options(arch.common.all.32 PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
-)
-
 
 ############################### Applying Flags ###############################
 

--- a/alkos/kernel/arch/x86_64/kernel/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/kernel/CMakeLists.txt
@@ -33,11 +33,8 @@ target_link_options(alkos.kernel PRIVATE
 
 ######################### Setting Custom Properties ##########################
 
-target_compile_options(alkos.kernel PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
+target_link_libraries(alkos.kernel PRIVATE
+        target.properties
 )
 
 ########################## CXX Global Constructors ###########################

--- a/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
@@ -1,28 +1,16 @@
 message(STATUS "Configuring x86_64 32-bit loader")
 
-############################## Finding Sources ###############################
-
-# TODO: Use alkos_find_sources() to find Sources
-# But this requires adding another function that will
-# handle adding compiler flags appropriately for 32-bit .c, .cpp and .asm files
-file(GLOB_RECURSE ARCH_SOURCES_32
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
-)
-
-file(GLOB_RECURSE ARCH_ASM_32
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.s"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.S"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.asm"
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.nasm"
-)
 
 #################################### Exec ####################################
 
 add_executable(alkos.loader32
-        ${ARCH_SOURCES_32}
-        ${ARCH_ASM_32}
 )
+
+############################## Finding Sources ###############################
+
+alkos_target_sources(alkos.loader32)
+
+############################## Finding CXX Compiler ############################
 
 message(STATUS "32 bit compiler: ${CMAKE_CXX_COMPILER_32}")
 set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_COMPILER_32} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")

--- a/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/loader32/CMakeLists.txt
@@ -33,9 +33,7 @@ target_include_directories(alkos.loader32 PRIVATE .)
 
 ################################ Exec Flags ##################################
 
-set_source_files_properties(${ARCH_SOURCES_32} PROPERTIES COMPILE_FLAGS "-m32")
-
-set_source_files_properties(${ARCH_ASM_32} PROPERTIES COMPILE_FLAGS "-f elf32 ")
+target_link_libraries(alkos.loader32 PRIVATE target.properties.32)
 
 set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> <INCLUDES> <FLAGS> -o <OBJECT> <SOURCE>")
 

--- a/alkos/kernel/thirdparty/uacpi/CMakeLists.txt
+++ b/alkos/kernel/thirdparty/uacpi/CMakeLists.txt
@@ -36,9 +36,8 @@ target_link_libraries(uacpi PRIVATE libk)
 
 ######################### Setting Custom Properties ##########################
 
-target_compile_options(uacpi PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
+target_link_libraries(uacpi PRIVATE
+        target.properties
 )
 
 # Propagate the uACPI library to the parent scope

--- a/alkos/libc/CMakeLists.txt
+++ b/alkos/libc/CMakeLists.txt
@@ -30,17 +30,7 @@ set_target_properties(lib${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 
 ############################# Setting Custom Properties #########################
 
-target_compile_options(lib${LIB_NAME} PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
-)
-target_compile_options(lib${LIB_NAME}.32 PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
-        "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
-)
-
+target_link_libraries(lib${LIB_NAME} PUBLIC target.properties)
 
 ############################### Adding includes ###############################
 

--- a/alkos/libc/arch/x86_64/CMakeLists.txt
+++ b/alkos/libc/arch/x86_64/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(lib${LIB_NAME}.32 PRIVATE
 
 ############################# Setting Custom Properties #########################
 
-target_link_libraries(lib${LIB_NAME}.32 INTERFACE target.properties.32)
+target_link_libraries(lib${LIB_NAME}.32 PUBLIC target.properties.32)
 
 ################################# Dependencies ################################
 

--- a/alkos/libc/arch/x86_64/CMakeLists.txt
+++ b/alkos/libc/arch/x86_64/CMakeLists.txt
@@ -15,6 +15,10 @@ target_include_directories(lib${LIB_NAME}.32 PRIVATE
         ../../internal
 )
 
+############################# Setting Custom Properties #########################
+
+target_link_libraries(lib${LIB_NAME}.32 INTERFACE target.properties.32)
+
 ################################# Dependencies ################################
 
 add_dependencies(lib${LIB_NAME}.32 lib${LIB_NAME})

--- a/alkos/toolchains/x86_64-conf.cmake
+++ b/alkos/toolchains/x86_64-conf.cmake
@@ -44,7 +44,9 @@ if (NOT TARGET target.properties)
   message(FATAL_ERROR "target.properties INTERFACE library is not defined. This should be defined by main CMakeLists.txt")
 endif ()
 
-#################################### 64 bit ####################################
+#------------------------------------------------------------------------------#
+#                                    64 bit                                    #
+#------------------------------------------------------------------------------#
 
 target_compile_options(target.properties INTERFACE
     "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
@@ -53,8 +55,9 @@ target_compile_options(target.properties INTERFACE
     "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
     "$<$<COMPILE_LANGUAGE:ASM_NASM>:-f elf64>"
 )
-
-#################################### 32 bit ####################################
+#------------------------------------------------------------------------------#
+#                                    32 bit                                    #
+#------------------------------------------------------------------------------#
 
 add_library(target.properties.32 INTERFACE)
 target_compile_options(target.properties.32 INTERFACE

--- a/alkos/toolchains/x86_64-conf.cmake
+++ b/alkos/toolchains/x86_64-conf.cmake
@@ -35,3 +35,31 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RELEAS
 else ()
     message(FATAL_ERROR "UNKNOWN BUILD TYPE: ${CMAKE_BUILD_TYPE}")
 endif ()
+
+################################################################################
+#                         Property Interface Libraries                         #
+################################################################################
+
+if (NOT TARGET target.properties)
+  message(FATAL_ERROR "target.properties INTERFACE library is not defined. This should be defined by main CMakeLists.txt")
+endif ()
+
+#################################### 64 bit ####################################
+
+target_compile_options(target.properties INTERFACE
+    "$<$<COMPILE_LANGUAGE:CXX>:-mcmodel=kernel>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-mno-red-zone>"
+    "$<$<COMPILE_LANGUAGE:C>:-mcmodel=kernel>"
+    "$<$<COMPILE_LANGUAGE:C>:-mno-red-zone>"
+    "$<$<COMPILE_LANGUAGE:ASM_NASM>:-f elf64>"
+)
+
+#################################### 32 bit ####################################
+
+add_library(target.properties.32 INTERFACE)
+target_compile_options(target.properties.32 INTERFACE
+    "$<$<COMPILE_LANGUAGE:CXX>:-m32>"
+    "$<$<COMPILE_LANGUAGE:C>:-m32>"
+    "$<$<COMPILE_LANGUAGE:ASM_NASM>:-f elf32>"
+)
+

--- a/scripts/config/configure.bash
+++ b/scripts/config/configure.bash
@@ -14,7 +14,7 @@ declare -A CONFIGURE_TOOLCHAINS=(
 )
 
 declare -A CONFIGURE_FLAGS=(
-  ["x86_64"]="${CONFIGURE_TOOLCHAIN_DIR}/x86_64-flags.cmake"
+  ["x86_64"]="${CONFIGURE_TOOLCHAIN_DIR}/x86_64-conf.cmake"
 )
 
 declare -A CONFIGURE_BUILD_TYPES_DESC=(


### PR DESCRIPTION
# Summary

CMakeLists now includes a target to which to link against. It sets all the necessary properties.
Idea is -> there is 1 main property interface library for almost anything.
If arch requires some custom one, it's defined in a .cmake file of the arch, and the existance of this library is a contract between the arch CMakeLists.txt and the arch configuration file. I think this is rather clean.

# Important!
Meddling with this stuff can easily introduce some very subtle bugs if a property for some reason isn't applied to a target etc. So I hope the tests will catch if anything like that was introduced. This PR needs to be approached with care for typos / mistakes etc that could subtly break this.

# Things done
- Renamed x86_64-flags.cmake to x86_64-conf.cmake as i added the property libraries here. Maybe split into two files? But I dont feel there is a need currently.
- Updated all CMakeLists.txt to simply link against those interface libraries and removed much redundant code.

#158 Link to previous part of the refactor